### PR TITLE
Chore/ Convert commands and handlers to classes

### DIFF
--- a/src/command_base_classes/split_arg_command.js
+++ b/src/command_base_classes/split_arg_command.js
@@ -1,0 +1,8 @@
+module.exports = class splitArgCommand {
+	static call(message, argString) {
+		this.execute(message, argString.split(/ +/));
+	}
+	static execute() {
+		throw new Error('execute() has not been overridden');
+	}
+}

--- a/src/command_base_classes/string_arg_command.js
+++ b/src/command_base_classes/string_arg_command.js
@@ -1,0 +1,8 @@
+module.exports = class stringArgCommand {
+	static call(message, argString) {
+		this.execute(message, argString);
+	}
+	static execute() {
+		throw new Error('execute() has not been overridden');
+	}
+}

--- a/src/command_handler.js
+++ b/src/command_handler.js
@@ -1,12 +1,12 @@
 const { prefix } = require('./config.json');
 
-module.exports = {
-	handleCommandCall(message) {
+module.exports = class CommandHandler {
+	static handleCommandCall(message) {
 		const commandName = isolateCommandName(message);
 		if (isCallingInvalidCommand(message, commandName)) return;
 		const commandArgString = isolateCommandArgString(message, commandName);
 		callCommand(message, commandName, commandArgString);
-	},
+	}
 };
 
 function isolateCommandName(message) {
@@ -19,10 +19,5 @@ function isCallingInvalidCommand(message, commandName) {
 	return !message.client.commands.has(commandName);
 }
 function callCommand(message, commandName, commandArgString) {
-	const command = message.client.commands.get(commandName);
-	if (command.doSplitArgs) {
-		command.execute(message, commandArgString);
-	} else {
-		command.execute(message, commandArgString.split(/ +/));
-	}
+	message.client.commands.get(commandName).call(message, commandArgString);
 }

--- a/src/command_loader.js
+++ b/src/command_loader.js
@@ -1,5 +1,5 @@
-module.exports = {
-	getCommandModules() {
+module.exports = class CommandLoader {
+	static getCommandModules() {
 		const commandFileNames = getCommandFileNames();
 		return getNameToModuleMap(commandFileNames);
 	}
@@ -23,7 +23,6 @@ function addCommandFileToMap(map, fileName) {
 function checkThatCommandMatchesTemplate(module, fileName) {
 	checkThatCommandHasVal(module.name, 'name', fileName);
 	checkThatCommandHasVal(module.description, 'description', fileName);
-	checkThatCommandHasVal(module.doSplitArgs, 'doSplitArgs', fileName);
 	if (module.name + '.js' !== fileName) throw new Error(`command.name is not equal to file name in ${fileName}`);
 }
 function checkThatCommandHasVal(val, valName, fileName) {

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,11 +1,12 @@
-module.exports = {
-	name: 'help',
-	description: 'Gives you a list of all commands or information about a specific command',
-	doSplitArgs: true,
-	execute(message, args) {
+const splitArgCommand = require('./../command_base_classes/split_arg_command');
+
+module.exports = class help extends splitArgCommand{
+	static name = 'help';
+	static description = 'Gives you a list of all commands or information about a specific command';
+	static execute(message, args) {
 		return message.channel.send(
 				Array.from(message.client.commands.keys())
 				.join(',\n')
 		);
-	},
+	}
 }

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,8 +1,9 @@
-module.exports = {
-	name: 'ping',
-	description: 'Pings me!',
-	doSplitArgs: false,
-	execute(message, args) {
+const stringArgCommand = require('./../command_base_classes/string_arg_command.js');
+
+module.exports = class ping extends stringArgCommand {
+	static name = 'ping';
+	static description = 'Pings me!';
+	static execute(message, args) {
 		return message.channel.send('poggers');
-	},
+	}
 }

--- a/src/commands/version.js
+++ b/src/commands/version.js
@@ -1,10 +1,10 @@
-const { version } = require('./../config.json');
+const stringArgCommand = require('./../command_base_classes/string_arg_command.js');
+const currentVersion = require('./../config.json').version;
 
-module.exports = {
-	name: 'version',
-	description: 'Gives you the current version of the bot',
-	doSplitArgs: false,
-	execute(message, args) {
-		return message.channel.send(`Current version: v${version}.`);
-	},
+module.exports = class version extends stringArgCommand {
+	static name = 'version';
+	static description = 'Gives you the current version of the bot';
+	static execute(message, args) {
+		return message.channel.send(`Current version: v${currentVersion}.`);
+	}
 }

--- a/src/message_handler.js
+++ b/src/message_handler.js
@@ -1,12 +1,12 @@
 const CommandHandler = require('./command_handler');
 const { prefix } = require('./config.json');
 
-module.exports = {
-	handleMessage(message) {
+module.exports = class MessageHandler {
+	static handleMessage(message) {
 		if (doesNotStartWithPrefix(message)) return;
 		if (isAuthorBot(message)) return;
 		CommandHandler.handleCommandCall(message);
-	},
+	}
 };
 
 function doesNotStartWithPrefix(message) {


### PR DESCRIPTION
- All commands and handlers are now classes
- Splitting arguments are now determined with polymorphism rather than an if-else (command.call() get's called, which will format the arguments correctly before calling command.execute())